### PR TITLE
Mark v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "plutus-ledger-api"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "data-encoding",
  "lbr-prelude",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plutus-ledger-api"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,17 @@ repository = "https://github.com/mlabs-haskell/plutus-ledger-api-rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proptest = "1.3.1"
-lbr-prelude = { git = "https://github.com/mlabs-haskell/lambda-buffers.git", rev = "7adcef1ea98dbfe9b3c4c527db3c499e078cb4d6", optional = true }
-serde_json = { version = "1.0.107", features = [
+proptest = "^1.3.1"
+lbr-prelude = { version = "0.1.0", optional = true }
+serde_json = { version = "^1.0.107", features = [
   "arbitrary_precision",
 ], optional = true }
-num-bigint = "0.4.4"
-serde = { version = "1.0.189", features = ["derive"], optional = true }
-true = { version = "0.1.0", optional = true }
-data-encoding = { version = "2.4.0", optional = true }
-thiserror = "1.0.50"
-linked-hash-map = "0.5.6"
+num-bigint = "~0.4"
+serde = { version = "^1.0.189", features = ["derive"], optional = true }
+true = { version = "~0.1.0", optional = true }
+data-encoding = { version = "^2.4.0", optional = true }
+thiserror = "^1.0.50"
+linked-hash-map = "~0.5.6"
 
 [features]
 serde = ["dep:serde", "num-bigint/serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "plutus-ledger-api"
 version = "1.0.0"
 edition = "2021"
+license = "Apache-2.0"
+description = "Plutus Ledger types and utilities implemented in Rust"
+repository = "https://github.com/mlabs-haskell/plutus-ledger-api-rust"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
TODO:
- [x] set versions to 1.0.0
- [x] fill in missing Cargo metadata
- [x] use published lbr-prelude