### PR TITLE
Add arb_natural and fix negative indices

### DIFF
--- a/plutus-ledger-api/src/generators/correct/v1.rs
+++ b/plutus-ledger-api/src/generators/correct/v1.rs
@@ -2,7 +2,7 @@
 //!
 //! These strategies always return valid values.
 use crate::feature_traits::FeatureTraits;
-use crate::generators::correct::primitive::{arb_bool, arb_bytes, arb_integer};
+use crate::generators::correct::primitive::{arb_bool, arb_bytes, arb_integer, arb_natural};
 use crate::plutus_data::PlutusData;
 use crate::v1::address::{
     Address, CertificateIndex, ChainPointer, Credential, Slot, StakingCredential, TransactionIndex,
@@ -85,7 +85,7 @@ pub fn arb_script_hash() -> impl Strategy<Value = ScriptHash> {
 pub fn arb_value() -> impl Strategy<Value = Value> {
     prop_oneof![
         arb_native_tokens(),
-        (arb_native_tokens(), arb_integer()).prop_map(|(Value(outer_dict), amount)| {
+        (arb_native_tokens(), arb_natural()).prop_map(|(Value(outer_dict), amount)| {
             let mut outer_dict = outer_dict.clone();
             let inner_dict = BTreeMap::from([(TokenName::ada(), amount)]);
             outer_dict.insert(CurrencySymbol::Ada, inner_dict);
@@ -98,7 +98,7 @@ pub fn arb_value() -> impl Strategy<Value = Value> {
 pub fn arb_native_tokens() -> impl Strategy<Value = Value> {
     btree_map(
         arb_minting_policy_hash().prop_map(CurrencySymbol::NativeToken),
-        btree_map(arb_token_name(), arb_integer(), 5),
+        btree_map(arb_token_name(), arb_natural(), 5),
         5,
     )
     .prop_map(Value)
@@ -237,17 +237,17 @@ pub fn arb_chain_pointer() -> impl Strategy<Value = ChainPointer> {
 
 /// Strategy to generate a slot number
 pub fn arb_slot() -> impl Strategy<Value = Slot> {
-    arb_integer().prop_map(Slot)
+    arb_natural().prop_map(Slot)
 }
 
 /// Strategy to generate a transaction index
 pub fn arb_transaction_index() -> impl Strategy<Value = TransactionIndex> {
-    arb_integer().prop_map(TransactionIndex)
+    arb_natural().prop_map(TransactionIndex)
 }
 
 /// Strategy to generate a certificate index.
 pub fn arb_certificate_index() -> impl Strategy<Value = CertificateIndex> {
-    arb_integer().prop_map(CertificateIndex)
+    arb_natural().prop_map(CertificateIndex)
 }
 
 /// Strategy to generate a staking credential
@@ -273,7 +273,7 @@ pub fn arb_transaction_hash() -> impl Strategy<Value = TransactionHash> {
 
 /// Strategy to generate a transaction input
 pub fn arb_transaction_input() -> impl Strategy<Value = TransactionInput> {
-    (arb_transaction_hash(), arb_integer()).prop_map(|(transaction_id, index)| TransactionInput {
+    (arb_transaction_hash(), arb_natural()).prop_map(|(transaction_id, index)| TransactionInput {
         transaction_id,
         index,
     })
@@ -318,7 +318,7 @@ pub fn arb_d_cert() -> impl Strategy<Value = DCert> {
             .prop_map(|(sc, pkh)| DCert::DelegDelegate(sc, pkh)),
         (arb_payment_pub_key_hash(), arb_payment_pub_key_hash())
             .prop_map(|(p1, p2)| DCert::PoolRegister(p1, p2)),
-        (arb_payment_pub_key_hash(), arb_integer()).prop_map(|(pkh, i)| DCert::PoolRetire(pkh, i)),
+        (arb_payment_pub_key_hash(), arb_natural()).prop_map(|(pkh, i)| DCert::PoolRetire(pkh, i)),
         Just(DCert::Genesis),
         Just(DCert::Mir)
     ]
@@ -343,7 +343,7 @@ pub fn arb_transaction_info() -> impl Strategy<Value = TransactionInfo> {
         arb_value(),
         arb_value(),
         vec(arb_d_cert(), 5),
-        vec((arb_staking_credential(), arb_integer()), 5),
+        vec((arb_staking_credential(), arb_natural()), 5),
         arb_plutus_interval_posix_time(),
         vec(arb_payment_pub_key_hash(), 5),
         vec((arb_datum_hash(), arb_datum()), 5),

--- a/plutus-ledger-api/src/generators/correct/v2.rs
+++ b/plutus-ledger-api/src/generators/correct/v2.rs
@@ -11,7 +11,7 @@ use proptest::option;
 use proptest::prelude::{prop_oneof, Just};
 use proptest::strategy::Strategy;
 
-use super::primitive::arb_integer;
+use super::primitive::arb_natural;
 use super::v1::{
     arb_assoc_map, arb_d_cert, arb_payment_pub_key_hash, arb_plutus_interval_posix_time,
     arb_redeemer, arb_script_purpose, arb_staking_credential, arb_transaction_hash,
@@ -58,7 +58,7 @@ pub fn arb_transaction_info() -> impl Strategy<Value = TransactionInfo> {
         arb_value(),
         arb_value(),
         vec(arb_d_cert(), 5),
-        arb_assoc_map(arb_staking_credential(), arb_integer()),
+        arb_assoc_map(arb_staking_credential(), arb_natural()),
         arb_plutus_interval_posix_time(),
         vec(arb_payment_pub_key_hash(), 5),
         arb_assoc_map(arb_script_purpose(), arb_redeemer()),


### PR DESCRIPTION
This fixes generation of negative integers for types where it doesn't make sense (e.g CertificateIndex, Slot etc)

I do wonder how this passed through testing. Perhaps we don't have tests for sanity checking types yet